### PR TITLE
use conda-build 3 to simplify recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,16 +12,16 @@ source:
 build:
     number: 0
     features:
-        - vc9  # [win and py27]
-        - vc10  # [win and py34]
-        - vc14  # [win and py>=35]
-    skip: true  # [win and py>35]
+        - vc{{ vc }}  # [win]
+    run_exports:
+      # mostly OK, but some scary symbol removal.  Let's try for trusting them.
+      #    https://abi-laboratory.pro/tracker/timeline/zlib/
+        - {{ pin_subpackage('zlib', max_pin='x.x')
 
 requirements:
     build:
-        - python  # [win]
         - cmake  # [win]
-        - msinttypes  # [win and py<35]
+        - msinttypes  # [win and vc<14]
         - {{ compiler('c') }}
 
 test:


### PR DESCRIPTION
note that using vc<14 depends on conda-build 3.0.10 (currently unreleased) or conda-build master.

This assumes a user-wide conda_build_config.yaml with code like:

```
vc:
  - 9
  - 14
c_compiler:      # [win]
  - vs2008       # [win]
  - vs2015       # [win]
cxx_compiler:    # [win]
  - vs2008       # [win]
  - vs2015       # [win]
zip_keys:
  -                 # [win]
    - vc            # [win]
    - c_compiler    # [win]
    - cxx_compiler  # [win]
```