### PR TITLE
zlib 1.2.12

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.2.11" %}
+{% set version = "1.2.12" %}
 
 package:
     name: zlib
@@ -6,10 +6,10 @@ package:
 
 source:
     url: http://zlib.net/zlib-{{ version }}.tar.gz
-    sha256: c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1
+    sha256: 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
 
 build:
-    number: 5
+    number: 0
     run_exports:
         # mostly OK, but some scary symbol removal.  Let's try for trusting them.
         #    https://abi-laboratory.pro/tracker/timeline/zlib/
@@ -34,15 +34,14 @@ test:
 about:
     home: http://zlib.net/
     # http://zlib.net/zlib_license.html
-    license: zlib
+    license: Zlib
     summary: Massively spiffy yet delicately unobtrusive compression library
     license_family: Other
     license_file: license.txt
-    
     description: |
       zlib is designed to be a free, general-purpose, lossless data-compression
       library for use on virtually any computer hardware and operating system.
-    doc_url: http://zlib.net/manual.html
+    doc_url: https://zlib.net/manual.html
     dev_url: https://github.com/madler/zlib
 
 extra:


### PR DESCRIPTION
Changelog:

> Version 1.2.12 has these key improvements over 1.2.11:
>
> * Fix a deflate bug when using the Z_FIXED strategy that can result in out-of-bound accesses.
> * Fix a deflate bug when the window is full in deflate_stored().
> * Speed up CRC-32 computations by a factor of 1.5 to 3.
> * Use the hardware CRC-32 instruction on ARMv8 processors.
> * Speed up crc32_combine() with powers of x tables.
> * Add crc32_combine_gen() and crc32_combine_op() for fast combines.
>
> Due to the bug fixes, any installations of 1.2.11 should be replaced with 1.2.12.