### PR TITLE
Changes:

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,22 +1,40 @@
+:: cmd
 set LIB=%LIBRARY_LIB%;%LIB%
 set LIBPATH=%LIBRARY_LIB%;%LIBPATH%
 set INCLUDE=%LIBRARY_INC%;%INCLUDE%;%RECIPE_DIR%
 
-:: Configure.
-cmake -G "NMake Makefiles" ^
-      -D CMAKE_BUILD_TYPE=Release ^
-      -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
-      -D CMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX% ^
-      %SRC_DIR%
+:: Isolate the build.
+mkdir Build
+cd Build
+if errorlevel 1 exit /b 1
+
+
+:: Generate the build files.
+echo "Generating the build files."
+cmake .. %CMAKE_ARGS% ^
+      -G"NMake Makefiles" ^
+      -DCMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
+      -DCMAKE_INSTALL_PREFIX=%LIBRARY_PREFIX% ^
+      -DCMAKE_BUILD_TYPE=Release
 if errorlevel 1 exit 1
+
 
 :: Build.
-cmake --build %SRC_DIR% --target INSTALL --config Release
-if errorlevel 1 exit 1
+echo "Building..."
+nmake
+if errorlevel 1 exit /b 1
 
-:: Test.
-ctest
-if errorlevel 1 exit 1
+
+:: Perforem tests.
+echo "Testing..."
+ctest -VV --output-on-failure
+
+
+:: Install.
+echo "Installing..."
+nmake install
+if errorlevel 1 exit /b 1
+
 
 :: Some OSS libraries are happier if z.lib exists, even though it's not typical on Windows.
 copy %LIBRARY_LIB%\zlib.lib %LIBRARY_LIB%\z.lib || exit 1
@@ -30,3 +48,7 @@ copy %RECIPE_DIR%\license.txt %SRC_DIR%\license.txt || exit 1
 :: python>=3.10 depend on this being at %PREFIX%
 copy %LIBRARY_BIN%\zlib.dll %PREFIX%\zlib.dll || exit 1
 
+
+:: Error free exit.
+echo "Error free exit!"
+exit 0

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,41 +12,27 @@ export CFLAGS="${CFLAGS} -fPIC"
 export CXXFLAGS="${CXXFLAGS} -fPIC"
 
 
-if [[ ${target_platform} == linux-aarch64 ]]; then
-
-  echo "Configuring..."
-  ./configure --prefix=${PREFIX} --shared
-
-  echo "Building..."
-  make -j${CPU_COUNT} ${VERBOSE_AT}
-  make check
-
-else
-
-  # Isolate the build.
-  mkdir -p Build
-  cd Build || exit 1
+# Isolate the build.
+mkdir -p Build
+cd Build || exit 1
 
 
-
-  # Generate the build files.
-  echo "Generating the build files."
-  cmake .. ${CMAKE_ARGS} \
+# Generate the build files.
+echo "Generating the build files."
+cmake .. ${CMAKE_ARGS} \
       -G"Unix Makefiles" \
       -DCMAKE_PREFIX_PATH=$PREFIX \
       -DCMAKE_INSTALL_PREFIX=$PREFIX \
       -DCMAKE_BUILD_TYPE=Release \
 
-  # Build.
-  echo "Building..."
-  make  -j${CPU_COUNT} || exit 1
+# Build.
+echo "Building..."
+make  -j${CPU_COUNT} || exit 1
 
 
-  # Perform tests.
-  echo "Testing..."
-  ctest -VV --output-on-failure || exit 1
-
-fi
+# Perform tests.
+echo "Testing..."
+ctest -VV --output-on-failure || exit 1
 
 
 # Installing

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -12,30 +12,41 @@ export CFLAGS="${CFLAGS} -fPIC"
 export CXXFLAGS="${CXXFLAGS} -fPIC"
 
 
-# Isolate the build.
-mkdir -p Build
-cd Build || exit 1
+if [[ ${target_platform} == linux-aarch64 ]]; then
+
+  echo "Configuring..."
+  ./configure --prefix=${PREFIX} --shared
+
+  echo "Building..."
+  make -j${CPU_COUNT} ${VERBOSE_AT}
+  make check
+
+else
+
+  # Isolate the build.
+  mkdir -p Build
+  cd Build || exit 1
 
 
 
-# Generate the build files.
-echo "Generating the build files."
-cmake .. ${CMAKE_ARGS} \
+  # Generate the build files.
+  echo "Generating the build files."
+  cmake .. ${CMAKE_ARGS} \
       -G"Unix Makefiles" \
       -DCMAKE_PREFIX_PATH=$PREFIX \
       -DCMAKE_INSTALL_PREFIX=$PREFIX \
       -DCMAKE_BUILD_TYPE=Release \
 
+  # Build.
+  echo "Building..."
+  make  -j${CPU_COUNT} || exit 1
 
 
-# Build.
-echo "Building..."
-make -d || exit 1
+  # Perform tests.
+  echo "Testing..."
+  ctest -VV --output-on-failure || exit 1
 
-
-# Perform tests.
-echo "Testing..."
-ctest -VV --output-on-failure || exit 1
+fi
 
 
 # Installing

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -30,7 +30,7 @@ cmake .. ${CMAKE_ARGS} \
 
 # Build.
 echo "Building..."
-make || exit 1
+make -d || exit 1
 
 
 # Perform tests.

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -11,6 +11,13 @@ fi
 export CFLAGS="${CFLAGS} -fPIC"
 export CXXFLAGS="${CXXFLAGS} -fPIC"
 
+# linux-aarch64 activations fails to set `ar` tool. This can be
+# removed when activations is corrected.
+if [[ "${target_platform}" == linux-aarch64 ]]; then
+  if [[ -n "$AR" ]]; then
+      CMAKE_ARGS="${CMAKE_ARGS} -DCMAKE_AR=${AR}"
+  fi
+fi
 
 # Isolate the build.
 mkdir -p Build

--- a/recipe/license.txt
+++ b/recipe/license.txt
@@ -1,7 +1,7 @@
   zlib.h -- interface of the 'zlib' general purpose compression library
-  version 1.2.7, May 2nd, 2012
+  version 1.2.12, March 11th, 2022
 
-  Copyright (C) 1995-2012 Jean-loup Gailly and Mark Adler
+  Copyright (C) 1995-2022 Jean-loup Gailly and Mark Adler
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
     sha256: 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
 
 build:
-    number: 0
+    number: 1
     run_exports:
         # mostly OK, but some scary symbol removal.  Let's try for trusting them.
         #    https://abi-laboratory.pro/tracker/timeline/zlib/
@@ -25,11 +25,20 @@ requirements:
         - msinttypes  # [win and vc<14]
         - make  # [not win]
     host:
-        - ripgrep
+        - ripgrep         # Should this be removed?
 
 test:
     commands:
-        - test -f ${PREFIX}/lib/libz.a  # [unix]
+       - test -f ${PREFIX}/include/zlib.h  # [unix]
+       - test -f ${PREFIX}/lib/libz.a      # [unix]
+       - test -f ${PREFIX}/lib/libz.so     # [linux]
+       - test -f ${PREFIX}/lib/libz.dylib  # [osx]
+       - if not exist %PREFIX%/Library/include/zlib.h exit 1         # [win]
+       - if not exist %PREFIX%/Library/lib/z.lib exit 1              # [win]
+       - if not exist %PREFIX%/Library/lib/zdll.lib exit 1           # [win]
+       - if not exist %PREFIX%/Library/lib/zlib.lib exit 1           # [win]
+       - if not exist %PREFIX%/Library/lib/zlibstatic.lib exit 1     # [win]
+       - if not exist %PREFIX%/Library/bin/zlib.dll exit 1           # [win]
 
 about:
     home: http://zlib.net/
@@ -37,7 +46,9 @@ about:
     license: Zlib
     summary: Massively spiffy yet delicately unobtrusive compression library
     license_family: Other
-    license_file: license.txt
+    # Note: we copy 'recipe/license.txt' which contains the header from `zlib.h`.
+    # Correct update of this recipe requires an update of `recipe/license.txt`.
+    license_file: zlib.h
     description: |
       zlib is designed to be a free, general-purpose, lossless data-compression
       library for use on virtually any computer hardware and operating system.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ test:
        - if not exist %PREFIX%/Library/bin/zlib.dll exit 1           # [win]
 
 about:
-    home: http://zlib.net/
+    home: https://zlib.net/
     # http://zlib.net/zlib_license.html
     license: Zlib
     summary: Massively spiffy yet delicately unobtrusive compression library


### PR DESCRIPTION
# Changes

Changes:
- Update build number from `0` to `1`.
- Convert [non win] from autotools/make to cmake/make.
- Improve tests to ensure artifacts are in the right place.
- Corrected license file and local contents.
- Ensure `ar` tool path is set for `linux-aarch64`.

Note: this is a version bump update to correct missing artifacts in
the previous `1.2.12` package.


# Review Information

## Source

https://github.com/madler/zlib/tree/v1.2.12


## License

https://github.com/madler/zlib/blob/v1.2.12/zlib.h

The license is `Zlib` and it's found in a header file.


## Upstream Changes

https://github.com/madler/zlib/blob/v1.2.12/ChangeLog

Note, this is a build bump, not a version bump.


## Issues

https://github.com/madler/zlib/issues

Note, this is a build bump, not a version bump. I didn't even look at the issues.


## Pins and Requireds

`ripgrep` is listed as required in the host section. I don't think
it's required, but I don't really have time for a full investigation
so I'm leaving it in.


## Testing

Tests were updated to ensure artifacts exist in the package.


# Closing Comments

Shared libraries now included and confirmed with tests.