### PR TITLE
Apply patch for CVE-2022-37434

### DIFF
--- a/recipe/CVE-2022-37434.patch
+++ b/recipe/CVE-2022-37434.patch
@@ -1,0 +1,16 @@
+diff --git a/inflate.c b/inflate.c
+index 7be8c63..2a3c4fe 100644
+--- a/inflate.c
++++ b/inflate.c
+@@ -764,8 +764,9 @@ int flush;
+                 if (copy > have) copy = have;
+                 if (copy) {
+                     if (state->head != Z_NULL &&
+-                        state->head->extra != Z_NULL) {
+-                        len = state->head->extra_len - state->length;
++                        state->head->extra != Z_NULL &&
++                        (len = state->head->extra_len - state->length) <
++                            state->head->extra_max) {
+                         zmemcpy(state->head->extra + len, next,
+                                 len + copy > state->head->extra_max ?
+                                 state->head->extra_max - len : copy);

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,10 @@ source:
     sha256: 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
     patches:
         - cmake-pkg-config.patch
+        - CVE-2022-37434.patch
 
 build:
-    number: 2
+    number: 3
     run_exports:
         # mostly OK, but some scary symbol removal.  Let's try for trusting them.
         #    https://abi-laboratory.pro/tracker/timeline/zlib/


### PR DESCRIPTION
Tweaked the CVE fix so it cleanly applies to zlib 1.2.12 sources.

@tobijk This outta do the trick. By the way, is there a way I can get permissions to add the "Build" label? Probably not but doesn't hurt to ask ;)