### PR TITLE
Adopt patches to address CVE-2022-37434

### DIFF
--- a/recipe/CVE-2022-37434-1.patch
+++ b/recipe/CVE-2022-37434-1.patch
@@ -1,0 +1,32 @@
+From eff308af425b67093bab25f80f1ae950166bece1 Mon Sep 17 00:00:00 2001
+From: Mark Adler <fork@madler.net>
+Date: Sat, 30 Jul 2022 15:51:11 -0700
+Subject: [PATCH] Fix a bug when getting a gzip header extra field with
+ inflate().
+
+If the extra field was larger than the space the user provided with
+inflateGetHeader(), and if multiple calls of inflate() delivered
+the extra header data, then there could be a buffer overflow of the
+provided space. This commit assures that provided space is not
+exceeded.
+
+(Ref: https://github.com/madler/zlib/commit/eff308af4)
+---
+ inflate.c | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+--- zlib-1.2.11.dfsg.orig/inflate.c
++++ zlib-1.2.11.dfsg/inflate.c
+@@ -758,9 +758,10 @@ int flush;
+                 copy = state->length;
+                 if (copy > have) copy = have;
+                 if (copy) {
++                    len = state->head->extra_len - state->length;
+                     if (state->head != Z_NULL &&
+-                        state->head->extra != Z_NULL) {
+-                        len = state->head->extra_len - state->length;
++                        state->head->extra != Z_NULL &&
++                        len < state->head->extra_max) {
+                         zmemcpy(state->head->extra + len, next,
+                                 len + copy > state->head->extra_max ?
+                                 state->head->extra_max - len : copy);

--- a/recipe/CVE-2022-37434-2.patch
+++ b/recipe/CVE-2022-37434-2.patch
@@ -1,0 +1,29 @@
+From 1eb7682f845ac9e9bf9ae35bbfb3bad5dacbd91d Mon Sep 17 00:00:00 2001
+From: Mark Adler <fork@madler.net>
+Date: Mon, 8 Aug 2022 10:50:09 -0700
+Subject: [PATCH] Fix extra field processing bug that dereferences NULL
+ state->head.
+
+The recent commit to fix a gzip header extra field processing bug
+introduced the new bug fixed here.
+
+(Ref: https://github.com/madler/zlib/commit/1eb7682f8)
+---
+ inflate.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+--- zlib-1.2.11.dfsg.orig/inflate.c
++++ zlib-1.2.11.dfsg/inflate.c
+@@ -758,10 +758,10 @@ int flush;
+                 copy = state->length;
+                 if (copy > have) copy = have;
+                 if (copy) {
+-                    len = state->head->extra_len - state->length;
+                     if (state->head != Z_NULL &&
+                         state->head->extra != Z_NULL &&
+-                        len < state->head->extra_max) {
++                        (len = state->head->extra_len - state->length) <
++                            state->head->extra_max) {
+                         zmemcpy(state->head->extra + len, next,
+                                 len + copy > state->head->extra_max ?
+                                 state->head->extra_max - len : copy);

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,9 +9,17 @@ source:
     sha256: 91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9
     patches:
         - cmake-pkg-config.patch
+        # Both patches are needed to remediate CVE-2022-37434; the "-1" patch
+        # had a bug that broke downstream packages like `curl`, which was
+        # addressed in the "-2" patch. As of 2022-09-07, these patches have
+        # been adopted by Debian and SUSE as fixes for the vulnerability.
+        # We're following Debian's pattern and keeping these patches separate
+        # (rather than consolidating them) to keep their provenance clear.
+        - CVE-2022-37434-1.patch
+        - CVE-2022-37434-2.patch
 
 build:
-    number: 2
+    number: 3
     run_exports:
         # mostly OK, but some scary symbol removal.  Let's try for trusting them.
         #    https://abi-laboratory.pro/tracker/timeline/zlib/


### PR DESCRIPTION
Pull in the pair of upstream patches to fix CVE-2022-37434. This PR supersedes PRs #13 and #14.