### PR TITLE
update to 1.2.13

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,7 +19,7 @@ source:
         # - CVE-2022-37434-2.patch
 
 build:
-    number: 3
+    number: 0
     run_exports:
         # mostly OK, but some scary symbol removal.  Let's try for trusting them.
         #    https://abi-laboratory.pro/tracker/timeline/zlib/


### PR DESCRIPTION
* updating to 1.2.13
* reset build number to 0
* remove obsolete CVE patches (CVE-2022-37434-2.patch is upstreamed, CVE-2022-37434-1.patch seems no longer be required)

CVE-2022-37434-1.patch: looks pretty suspicious, as it contains a potential null-pointer access, but hopefully it isn't looking to be required in new sources anymore