### PR TITLE
Update recipe for PKG-4571_codesign

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
     version: {{ version }}
 
 source:
-    url: http://zlib.net/zlib-{{ version }}.tar.gz
+    url: https://github.com/madler/zlib/releases/download/v{{ version }}/zlib-{{ version }}.tar.gz
     sha256: b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30
     patches:
         - cmake-pkg-config.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
         - cmake-pkg-config.patch
 
 build:
-    number: 0
+    number: 1
     run_exports:
         # mostly OK, but some scary symbol removal.  Let's try for trusting them.
         #    https://abi-laboratory.pro/tracker/timeline/zlib/


### PR DESCRIPTION
Rebuild for PKG-4513 authenticode signing

Updated source url as the previous one is now invalid.