### PR TITLE
PKG-9450 zlib 1.2.13 rebuild

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,11 +11,11 @@ source:
         - cmake-pkg-config.patch
 
 build:
-    number: 1
+    number: 2
     run_exports:
         # mostly OK, but some scary symbol removal.  Let's try for trusting them.
         #    https://abi-laboratory.pro/tracker/timeline/zlib/
-        - {{ pin_subpackage('zlib', max_pin='x.x') }}
+        - {{ pin_subpackage('zlib', max_pin='x') }}
 
 requirements:
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,7 @@ build:
 
 requirements:
     build:
+        - {{ stdlib('c') }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}  # [win32]
         # Require `cmake-no-system` to break circular dependency;
@@ -26,10 +27,6 @@ requirements:
         - cmake-no-system
         - msinttypes  # [win and vc<14]
         - make  # [not win]
-        - patch  # [not win]
-        - m2-patch  # [win]
-    host:
-        - ripgrep         # Should this be removed?
 
 test:
     commands:


### PR DESCRIPTION
zlib 1.2.13

**Destination channel:** defaults

### Links

- [PKG-9450](https://anaconda.atlassian.net/browse/PKG-9450)
- dev_url: https://github.com/madler/zlib/tree/v1.2.13
- conda_forge: https://github.com/conda-forge/zlib-feedstock

### Explanation of changes:

- Loosen run_exports to max_pin='x'
- Fix linter errors


[PKG-9450]: https://anaconda.atlassian.net/browse/PKG-9450?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ