### PR TITLE
PKG-12839-zlib-1.3.2

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -63,6 +63,7 @@ if errorlevel 1 exit 1
 copy %LIBRARY_LIB%\z.lib  %LIBRARY_LIB%\zdll.lib      || exit 1
 copy %LIBRARY_LIB%\z.lib  %LIBRARY_LIB%\zlib.lib      || exit 1
 copy %LIBRARY_LIB%\zs.lib %LIBRARY_LIB%\zlibstatic.lib || exit 1
+copy %LIBRARY_BIN%\z.dll  %LIBRARY_BIN%\zlib.dll       || exit 1 
 copy %LIBRARY_BIN%\z.dll  %PREFIX%\zlib.dll            || exit 1
 
 :: Now copy winapi artifacts - LAST, after conda-build has

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -29,11 +29,10 @@ if errorlevel 1 exit 1
 :: https://docs.nvidia.com/deeplearning/cudnn/archives/cudnn-890/install-guide/index.html#install-zlib-windows
 :: v1.3.2 produces z.dll / zs.lib on Windows (OUTPUT_NAME z, static suffix s)
 :: Rename to the expected zlibwapi names
-copy /Y "z.dll"  "%LIBRARY_BIN%\zlibwapi.dll" || exit 1
-copy /Y "zs.lib" "%LIBRARY_LIB%\zlibwapi.lib" || exit 1
-copy /Y "z.dll"  "%LIBRARY_BIN%\zlib.dll" || exit 1
-copy /Y "zs.lib" "%LIBRARY_LIB%\zlib.lib" || exit 1
-copy /Y "zs.lib" "%LIBRARY_LIB%\zlibstatic.lib" || exit 1
+:: Stash winapi artifacts in a temp dir, do NOT touch %LIBRARY_*% yet
+mkdir "%SRC_DIR%\winapi_out"
+copy /Y "z.dll"  "%SRC_DIR%\winapi_out\zlibwapi.dll" || exit 1
+copy /Y "zs.lib" "%SRC_DIR%\winapi_out\zlibwapi.lib" || exit 1
 
 del /f /q CMakeCache.txt
 
@@ -59,11 +58,14 @@ if errorlevel 1 exit 1
 ctest --output-on-failure
 if errorlevel 1 exit 1
 
-:: Some OSS libraries are happier if z.lib exists, even though it's not typical on Windows.
-copy %LIBRARY_LIB%\zlib.lib %LIBRARY_LIB%\z.lib || exit 1
+:: Compat copies for regular zlib (z.lib is already installed
+:: as the DLL import lib; zs.lib is the static lib)
+copy %LIBRARY_LIB%\z.lib  %LIBRARY_LIB%\zdll.lib      || exit 1
+copy %LIBRARY_LIB%\z.lib  %LIBRARY_LIB%\zlib.lib      || exit 1
+copy %LIBRARY_LIB%\zs.lib %LIBRARY_LIB%\zlibstatic.lib || exit 1
+copy %LIBRARY_BIN%\z.dll  %PREFIX%\zlib.dll            || exit 1
 
-:: Qt in particular goes looking for this one (as of 4.8.7).
-copy %LIBRARY_LIB%\z.lib %LIBRARY_LIB%\zdll.lib || exit 1
-
-:: python>=3.10 depend on this being at %PREFIX%
-copy %LIBRARY_BIN%\z.dll %PREFIX%\zlib.dll || exit 1
+:: Now copy winapi artifacts - LAST, after conda-build has
+:: already seen the zlib package file list
+copy /Y "%SRC_DIR%\winapi_out\zlibwapi.dll" "%LIBRARY_BIN%\zlibwapi.dll" || exit 1
+copy /Y "%SRC_DIR%\winapi_out\zlibwapi.lib" "%LIBRARY_LIB%\zlibwapi.lib" || exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -10,8 +10,10 @@ cmake -G "NMake Makefiles" ^
       -D CMAKE_BUILD_TYPE=Release ^
       -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
       -D CMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX% ^
-      -D CMAKE_C_FLAGS="-DZLIB_WINAPI " ^
-      -D CMAKE_RELEASE_POSTFIX="wapi" ^
+      -D CMAKE_C_FLAGS="-DZLIB_WINAPI" ^
+      -D ZLIB_BUILD_SHARED=ON ^
+      -D ZLIB_BUILD_STATIC=ON ^
+      -D ZLIB_INSTALL=OFF ^
       %CMAKE_ARGS% %SRC_DIR%
 if errorlevel 1 exit 1
 
@@ -22,16 +24,16 @@ type CMakeCache.txt
 cmake --build %SRC_DIR% --config Release
 if errorlevel 1 exit 1
 
-:: Test.
-ctest --output-on-failure
-if errorlevel 1 exit 1
-
-
 :: Copy built zlibwapi.dll with the same name provided by https://www.winimage.com/zLibDll/index.html
 :: This is needed for example for cuDNN
 :: https://docs.nvidia.com/deeplearning/cudnn/archives/cudnn-890/install-guide/index.html#install-zlib-windows
-copy "zlibwapi.dll" "%LIBRARY_BIN%\zlibwapi.dll" || exit 1
-copy "zlibwapi.lib" "%LIBRARY_LIB%\zlibwapi.lib" || exit 1
+:: v1.3.2 produces z.dll / zs.lib on Windows (OUTPUT_NAME z, static suffix s)
+:: Rename to the expected zlibwapi names
+copy /Y "z.dll"  "%LIBRARY_BIN%\zlibwapi.dll" || exit 1
+copy /Y "zs.lib" "%LIBRARY_LIB%\zlibwapi.lib" || exit 1
+copy /Y "z.dll"  "%LIBRARY_BIN%\zlib.dll" || exit 1
+copy /Y "zs.lib" "%LIBRARY_LIB%\zlib.lib" || exit 1
+copy /Y "zs.lib" "%LIBRARY_LIB%\zlibstatic.lib" || exit 1
 
 del /f /q CMakeCache.txt
 
@@ -41,8 +43,10 @@ cmake -G "NMake Makefiles" ^
       -D CMAKE_BUILD_TYPE=Release ^
       -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
       -D CMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX% ^
-      -D INSTALL_PKGCONFIG_DIR=%LIBRARY_PREFIX%\lib\pkgconfig ^
-      %SRC_DIR%
+      -D ZLIB_BUILD_SHARED=ON ^
+      -D ZLIB_BUILD_STATIC=ON ^
+      -D ZLIB_INSTALL=ON ^
+      %CMAKE_ARGS% %SRC_DIR%
 if errorlevel 1 exit 1
 
 type CMakeCache.txt
@@ -59,7 +63,7 @@ if errorlevel 1 exit 1
 copy %LIBRARY_LIB%\zlib.lib %LIBRARY_LIB%\z.lib || exit 1
 
 :: Qt in particular goes looking for this one (as of 4.8.7).
-copy %LIBRARY_LIB%\zlib.lib %LIBRARY_LIB%\zdll.lib || exit 1
+copy %LIBRARY_LIB%\z.lib %LIBRARY_LIB%\zdll.lib || exit 1
 
 :: python>=3.10 depend on this being at %PREFIX%
-copy %LIBRARY_BIN%\zlib.dll %PREFIX%\zlib.dll || exit 1
+copy %LIBRARY_BIN%\z.dll %PREFIX%\zlib.dll || exit 1

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -4,6 +4,13 @@ set LIB=%LIBRARY_LIB%;%LIB%
 set LIBPATH=%LIBRARY_LIB%;%LIBPATH%
 set INCLUDE=%LIBRARY_INC%;%INCLUDE%
 
+:: zlib 1.3.2 hardcodes OUTPUT_NAME to "z". Override it back to match 1.3.1 names.
+:: This ensures DLLs get the expected internal PE names (zlib.dll, zlibwapi.dll)
+:: and import libs reference the correct DLL filenames.
+echo if( DEFINED ZLIB_OUTPUT_NAME ) >> "CMakeLists.txt"
+echo     set_target_properties(zlib PROPERTIES OUTPUT_NAME ${ZLIB_OUTPUT_NAME}) >> "CMakeLists.txt"
+echo endif() >> "CMakeLists.txt"
+
 :: Configure.
 :: -DZLIB_WINAPI switches to WINAPI calling convention. See Q7 in DLL_FAQ.txt.
 cmake -G "NMake Makefiles" ^
@@ -11,9 +18,7 @@ cmake -G "NMake Makefiles" ^
       -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
       -D CMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX% ^
       -D CMAKE_C_FLAGS="-DZLIB_WINAPI" ^
-      -D ZLIB_BUILD_SHARED=ON ^
-      -D ZLIB_BUILD_STATIC=ON ^
-      -D ZLIB_INSTALL=OFF ^
+      -D ZLIB_OUTPUT_NAME="zlibwapi" ^
       %CMAKE_ARGS% %SRC_DIR%
 if errorlevel 1 exit 1
 
@@ -24,15 +29,15 @@ type CMakeCache.txt
 cmake --build %SRC_DIR% --config Release
 if errorlevel 1 exit 1
 
+:: Test.
+ctest --output-on-failure
+if errorlevel 1 exit 1
+
 :: Copy built zlibwapi.dll with the same name provided by https://www.winimage.com/zLibDll/index.html
 :: This is needed for example for cuDNN
 :: https://docs.nvidia.com/deeplearning/cudnn/archives/cudnn-890/install-guide/index.html#install-zlib-windows
-:: v1.3.2 produces z.dll / zs.lib on Windows (OUTPUT_NAME z, static suffix s)
-:: Rename to the expected zlibwapi names
-:: Stash winapi artifacts in a temp dir, do NOT touch %LIBRARY_*% yet
-mkdir "%SRC_DIR%\winapi_out"
-copy /Y "z.dll"  "%SRC_DIR%\winapi_out\zlibwapi.dll" || exit 1
-copy /Y "zs.lib" "%SRC_DIR%\winapi_out\zlibwapi.lib" || exit 1
+copy "zlibwapi.dll" "%LIBRARY_BIN%\zlibwapi.dll" || exit 1
+copy "zlibwapi.lib" "%LIBRARY_LIB%\zlibwapi.lib" || exit 1
 
 del /f /q CMakeCache.txt
 
@@ -42,9 +47,8 @@ cmake -G "NMake Makefiles" ^
       -D CMAKE_BUILD_TYPE=Release ^
       -D CMAKE_PREFIX_PATH=%LIBRARY_PREFIX% ^
       -D CMAKE_INSTALL_PREFIX:PATH=%LIBRARY_PREFIX% ^
-      -D ZLIB_BUILD_SHARED=ON ^
-      -D ZLIB_BUILD_STATIC=ON ^
-      -D ZLIB_INSTALL=ON ^
+      -D ZLIB_OUTPUT_NAME="zlib" ^
+      -D INSTALL_PKGCONFIG_DIR=%LIBRARY_PREFIX%\lib\pkgconfig ^
       %CMAKE_ARGS% %SRC_DIR%
 if errorlevel 1 exit 1
 
@@ -58,15 +62,14 @@ if errorlevel 1 exit 1
 ctest --output-on-failure
 if errorlevel 1 exit 1
 
-:: Compat copies for regular zlib (z.lib is already installed
-:: as the DLL import lib; zs.lib is the static lib)
-copy %LIBRARY_LIB%\z.lib  %LIBRARY_LIB%\zdll.lib      || exit 1
-copy %LIBRARY_LIB%\z.lib  %LIBRARY_LIB%\zlib.lib      || exit 1
-copy %LIBRARY_LIB%\zs.lib %LIBRARY_LIB%\zlibstatic.lib || exit 1
-copy %LIBRARY_BIN%\z.dll  %LIBRARY_BIN%\zlib.dll       || exit 1 
-copy %LIBRARY_BIN%\z.dll  %PREFIX%\zlib.dll            || exit 1
+:: Some OSS libraries are happier if z.lib exists, even though it's not typical on Windows.
+copy %LIBRARY_LIB%\zlib.lib %LIBRARY_LIB%\z.lib || exit 1
 
-:: Now copy winapi artifacts - LAST, after conda-build has
-:: already seen the zlib package file list
-copy /Y "%SRC_DIR%\winapi_out\zlibwapi.dll" "%LIBRARY_BIN%\zlibwapi.dll" || exit 1
-copy /Y "%SRC_DIR%\winapi_out\zlibwapi.lib" "%LIBRARY_LIB%\zlibwapi.lib" || exit 1
+:: Install zlibstatic.lib for backwards compat.
+move %LIBRARY_LIB%\zs.lib %LIBRARY_LIB%\zlibstatic.lib || exit 1
+
+:: Qt in particular goes looking for this one (as of 4.8.7).
+copy %LIBRARY_LIB%\zlib.lib %LIBRARY_LIB%\zdll.lib || exit 1
+
+:: python>=3.10 depend on this being at %PREFIX%
+copy %LIBRARY_BIN%\zlib.dll %PREFIX%\zlib.dll || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,18 +33,16 @@ outputs:
       - lib/libz.so.*         # [linux]
       - lib/libz.*.dylib      # [osx]
       - Library/bin/zlib.dll  # [win]
-      - zlib.dll              # [win]
       - Library/bin/z.dll     # [win]
-      - z.dll                 # [win]
+      - zlib.dll              # [win]
     test:
       commands:
         - test ! -f ${PREFIX}/lib/libz.a              # [unix]
         - test ! -f ${PREFIX}/lib/libz${SHLIB_EXT}    # [unix]
         - test ! -f ${PREFIX}/include/zlib.h          # [unix]
         - if not exist %LIBRARY_BIN%\zlib.dll exit 1  # [win]
-        - if not exist %PREFIX%\zlib.dll exit 1       # [win]
         - if not exist %LIBRARY_BIN%\z.dll exit 1     # [win]
-        - if not exist %PREFIX%\z.dll exit 1          # [win]
+        - if not exist %PREFIX%\zlib.dll exit 1       # [win]
 
   - name: lib{{ name }}-wapi
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,6 +34,8 @@ outputs:
       - lib/libz.*.dylib      # [osx]
       - Library/bin/zlib.dll  # [win]
       - zlib.dll              # [win]
+      - Library/bin/z.dll     # [win]
+      - z.dll                 # [win]
     test:
       commands:
         - test ! -f ${PREFIX}/lib/libz.a              # [unix]
@@ -41,6 +43,8 @@ outputs:
         - test ! -f ${PREFIX}/include/zlib.h          # [unix]
         - if not exist %LIBRARY_BIN%\zlib.dll exit 1  # [win]
         - if not exist %PREFIX%\zlib.dll exit 1       # [win]
+        - if not exist %LIBRARY_BIN%\z.dll exit 1     # [win]
+        - if not exist %PREFIX%\z.dll exit 1          # [win]
 
   - name: lib{{ name }}-wapi
     build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "zlib" %}
-{% set version = "1.3.1" %}
+{% set version = "1.3.2" %}
 
 package:
   name: {{ name|lower }}-split
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://zlib.net/zlib-{{ version }}.tar.gz
-  sha256: 9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+  sha256: bb329a0a2cd0274d05519d61c667c062e06990d72e125ee2dfa8de64f0119d16
 
 build:
   number: 0
@@ -139,7 +139,7 @@ about:
   license_family: OTHER
   license_file: LICENSE
   doc_url: https://zlib.net/manual.html
-  dev_url: https://github.com/madler/zlib/tree/v1.3.1
+  dev_url: https://github.com/madler/zlib
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -55,10 +55,10 @@ outputs:
         - {{ name }} {{ version }}
         - {{ name }}-wapi {{ version }}
     files:
-      - Library/bin/zlibwapi.dll  # [win]
+      - Library/bin/zlibwapi.dll
     test:
       commands:
-        - if not exist "%LIBRARY_BIN%\zlibwapi.dll" exit 1  # [win]
+        - if not exist "%LIBRARY_BIN%\zlibwapi.dll" exit 1
 
   - name: {{ name }}
     build:
@@ -118,7 +118,7 @@ outputs:
         - {{ pin_subpackage('lib' + name + '-wapi', exact=True) }}
         - {{ pin_subpackage(name, exact=True) }}
     files:
-      - Library/lib/zlibwapi.lib   # [win]
+      - Library/lib/zlibwapi.lib
     test:
       requires:
         - {{ compiler('c') }}
@@ -126,8 +126,8 @@ outputs:
         - test_compile_flags.bat
         - test_compile_flags.c
       commands:
-        - if not exist %LIBRARY_LIB%\zlibwapi.lib exit 1   # [win]
-        - call test_compile_flags.bat "wapi"               # [win]
+        - if not exist %LIBRARY_LIB%\zlibwapi.lib exit 1
+        - call test_compile_flags.bat "wapi"
 
 about:
   home: https://zlib.net/
@@ -142,6 +142,9 @@ about:
   dev_url: https://github.com/madler/zlib
 
 extra:
+  skip-lints:
+    # incorrectly flags pin_subpackage as unpinned
+    - host_section_needs_exact_pinnings
   recipe-maintainers:
     - groutr
     - msarahan

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -33,7 +33,6 @@ outputs:
       - lib/libz.so.*         # [linux]
       - lib/libz.*.dylib      # [osx]
       - Library/bin/zlib.dll  # [win]
-      - Library/bin/z.dll     # [win]
       - zlib.dll              # [win]
     test:
       commands:
@@ -41,7 +40,6 @@ outputs:
         - test ! -f ${PREFIX}/lib/libz${SHLIB_EXT}    # [unix]
         - test ! -f ${PREFIX}/include/zlib.h          # [unix]
         - if not exist %LIBRARY_BIN%\zlib.dll exit 1  # [win]
-        - if not exist %LIBRARY_BIN%\z.dll exit 1     # [win]
         - if not exist %PREFIX%\zlib.dll exit 1       # [win]
 
   - name: lib{{ name }}-wapi


### PR DESCRIPTION
zlib 1.3.2

[PKG-12839](https://anaconda.atlassian.net/browse/PKG-12839)
dev_url: https://github.com/madler/zlib/tree/v1.3.2
conda_forge (not updated): https://github.com/conda-forge/zlib-feedstock

# Explanation of changes

1. The change is dictated due to some security issues fixes
2. Between v1.3.1 and v1.3.2 the CMakeLists.txt was completely rewritten. Since `cmake` is used by `win` target, the `bld.bat` required some changes:
  - new cmake flags
  - ~~remove `ctest` performed after first `cmake` command - it fails, because this test is much more extensive now and it tests installed component (install is performed at second stage)~~
  - ~~now libs are named `z.dll/z.lib` (instead of `zlib.dll/zlib.lib`) and `zs.lib` (instead of `zlibstatic.lib`). In order to keep naming compatibility, lib were copied with legacy names.~~

# Compatibility report

[compat_report.html](https://github.com/user-attachments/files/26090540/compat_report.html)

[PKG-12839]: https://anaconda.atlassian.net/browse/PKG-12839?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ